### PR TITLE
Pass context as ARGV[1]

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,7 +1,7 @@
 const exec = require('child_process').exec;
 
 exports.handler = function(event, context) {
-  const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(event) + "'", (result) => {
+  const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(event) + "' '" + JSON.stringify(context) + "'", (result) => {
     context.done(result);
   });
 


### PR DESCRIPTION
We want to use the `invokedFunctionArn` value from the lambda context to determine which environment we're in (sandbox/staging/production), and in order to do so, we need to make sure the context object (where that value is given), is passed in as an argument to our Ruby code.