### PR TITLE
Allow Rumbda Lambda to return JSON for API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ If testing the script locally, simply pass in a json as the first argument to th
 $ ruby main.rb "$(cat test_event.json)"
 ```
 
+## Return JSON for API Gateway
+If needing to return JSON from your lambda (e.g. for use in AWS API Gateway) write to a file path provided in your lambda's environment at key 'RUMBDA_RESULT_JSON_FILENAME'.
+
+```ruby
+File.open(ENV['RUMBDA_RESULT_JSON_FILENAME'], 'w') do |file|
+  file.write(JSON.dump({ statusCode: 200, body: '' }))
+end
+```
+
+The file contents should be valid JSON.
+
 ## Command Reference
 | Command        | Purpose                                                                                                                    |
 |:---------------|:---------------------------------------------------------------------------------------------------------------------------|

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 
 exports.handler = function(event, context, callback) {
   // In order to return a value and not deal with stdout rumbda watches a file.
-  const jsonFilePath = '/tmp/rumbda.json';
-  event['RUMBDA_RESULT_JSON_FILENAME'] = jsonFilePath;
+  const jsonFilePath = '/tmp/rumbda.' + Math.random() + '.json';
+  process.env['RUMBDA_RESULT_JSON_FILENAME'] = jsonFilePath;
 
   const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(event) + "'", (error, stdout, stderr) => {
     if (error) {
@@ -30,3 +30,4 @@ exports.handler = function(event, context, callback) {
   child.stdout.on('data', console.log);
   child.stderr.on('data', console.error);
 };
+

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -14,18 +14,13 @@ exports.handler = function(event, context, callback) {
 
     if (fs.existsSync(jsonFilePath)) {
       fs.readFile(jsonFilePath, 'utf8', function (err, data) {
-        if (err) {
-          fs.unlink(jsonFilePath); 
-
-          return callback(err);
-        }
-        if (data.length > 0) {
-          callback(null, JSON.parse(data));
-        } else {
-          callback(null, data);
-        }
-
         fs.unlink(jsonFilePath); 
+
+        if (err) {
+          callback(err);
+          return;
+        }
+        callback(null, (data.length > 0) ? JSON.parse(data) : null);
       });
     } else {
       callback(null);

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,8 +1,29 @@
 const exec = require('child_process').exec;
+const fs = require('fs');
 
-exports.handler = function(event, context) {
+exports.handler = function(event, context, callback) {
+  // In order to return a value and not deal with stdout rumbda watches a file.
+  const jsonFilePath = '/tmp/rumbda.json';
+  event['RUMBDA_RESULT_JSON_FILENAME'] = jsonFilePath;
+
   const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(event) + "'", (result) => {
-    context.done(result);
+    if (fs.existsSync(jsonFilePath)) {
+      fs.readFile(jsonFilePath, 'utf8', function (err, data) {
+        if (err) {
+          fs.unlink(jsonFilePath); 
+          return callback(err);
+        }
+        if (data.length > 0) {
+          callback(null, JSON.parse(data));
+        } else {
+          callback(null, data);
+        }
+
+        fs.unlink(jsonFilePath); 
+      });
+    } else {
+      callback(null, result);
+    }
   });
 
   child.stdout.on('data', console.log);

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -6,11 +6,17 @@ exports.handler = function(event, context, callback) {
   const jsonFilePath = '/tmp/rumbda.json';
   event['RUMBDA_RESULT_JSON_FILENAME'] = jsonFilePath;
 
-  const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(event) + "'", (result) => {
+  const child = exec('./ruby_wrapper ' + "'" +  JSON.stringify(event) + "'", (error, stdout, stderr) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
     if (fs.existsSync(jsonFilePath)) {
       fs.readFile(jsonFilePath, 'utf8', function (err, data) {
         if (err) {
           fs.unlink(jsonFilePath); 
+
           return callback(err);
         }
         if (data.length > 0) {
@@ -22,7 +28,7 @@ exports.handler = function(event, context, callback) {
         fs.unlink(jsonFilePath); 
       });
     } else {
-      callback(null, result);
+      callback(null);
     }
   });
 

--- a/lib/rumbda/version.rb
+++ b/lib/rumbda/version.rb
@@ -1,3 +1,3 @@
 module Rumbda
-  VERSION = '1.1.0.SNAPSHOT'.freeze
+  VERSION = '1.2.0.SNAPSHOT'.freeze
 end

--- a/lib/rumbda/version.rb
+++ b/lib/rumbda/version.rb
@@ -1,3 +1,3 @@
 module Rumbda
-  VERSION = '1.2.0.SNAPSHOT'.freeze
+  VERSION = '1.1.0.SNAPSHOT'.freeze
 end


### PR DESCRIPTION
I *think* this is passive.

API Gateway expects JSON to be returned from a Lambda.  This, no matter how hackish, accomplishes that.  The nodejs side of things passes a key in the event object to tell the ruby side of things where to write its JSON.  It's ugly but passive to the current way of doing things.  Also puts still behaves as before on the ruby side which was important.

I also updated to using callback rather than context.done() which is deprecated in Lambda's node v4.3 and v6.10 APIs.