### PR TITLE
Dockerized rumbda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:2.2.2
+
+RUN apt-get update && \
+    apt-get install zip unzip
+
+# TODO Tie rumbda gem version
+# https://docs.docker.com/engine/reference/builder/#using-arg-variables
+
+WORKDIR /app/
+
+# Install the version of bundler needed by traveling ruby
+RUN gem uninstall -a bundler && \
+  gem install bundler -v 1.9.9
+
+COPY rumbda-1.1.0.SNAPSHOT.gem .
+
+# TODO figure out how to share version number
+RUN gem install rumbda-1.1.0.SNAPSHOT.gem
+
+# Mount point to interact with the file system of the host.
+VOLUME /src
+WORKDIR /src
+ENTRYPOINT ["rumbda"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
 FROM ruby:2.2.2
 
+# The bundler mangling below is because of
+# traveling ruby as well as the dependency on ruby 2.2.2.
+
 RUN apt-get update && \
-    apt-get install zip unzip
+    apt-get install zip unzip && \
+    gem uninstall -a bundler && \
+    gem install bundler -v 1.9.9 
 
-# TODO Tie rumbda gem version
-# https://docs.docker.com/engine/reference/builder/#using-arg-variables
+# Rumbda version to build
+ARG VERSION
 
-WORKDIR /app/
+COPY rumbda-${VERSION}.gem /tmp
+WORKDIR /tmp
+RUN gem install rumbda-${VERSION}.gem
+RUN rm -rf /tmp
 
-# Install the version of bundler needed by traveling ruby
-RUN gem uninstall -a bundler && \
-  gem install bundler -v 1.9.9
-
-COPY rumbda-1.1.0.SNAPSHOT.gem .
-
-# TODO figure out how to share version number
-RUN gem install rumbda-1.1.0.SNAPSHOT.gem
-
-# Mount point to interact with the file system of the host.
+# Mount point to interact with the file system of the host
 VOLUME /src
 WORKDIR /src
+
+# Pass all commands to rumbda
 ENTRYPOINT ["rumbda"]
 


### PR DESCRIPTION
TODO:
* create utility script `rumbda-docker` to wrap docker calls
* README updates
* Script releases and tagging

This creates a Docker image that encapsulates rumbda's dependencies to reduce the burden of running rumbda (i.e. ruby 2.2.2 and specific bundler version).  It unfortunately results in a large image.

To build rumbda:
```bash
% gem build rumbda.gemspec 
WARNING:  no email specified
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rumbda
  Version: 1.2.0.SNAPSHOT
  File: rumbda-1.2.0.SNAPSHOT.gem

% docker build --build-arg VERSION=1.2.0.SNAPSHOT -t rumbda .
Sending build context to Docker daemon  461.8kB
Step 1/10 : FROM ruby:2.2.2
 ---> 81404453979d
Step 2/10 : RUN apt-get update &&     apt-get install zip unzip &&     gem uninstall -a bundler &&     gem install bundler -v 1.9.9
 ---> Using cache
 ---> c18b950704ef
Step 3/10 : ARG VERSION
 ---> Using cache
 ---> 0223c3d9223e
Step 4/10 : COPY rumbda-${VERSION}.gem /tmp
 ---> 6c8f393089b1
Removing intermediate container b7c321501639
Step 5/10 : WORKDIR /tmp
 ---> 2b7ca30d968e
Removing intermediate container a1fe7c8c7aeb
Step 6/10 : RUN gem install rumbda-${VERSION}.gem
 ---> Running in 5ab38d216553
Successfully installed thor-0.20.0
Successfully installed rumbda-1.2.0.SNAPSHOT
2 gems installed
 ---> 9620a748d4da
Removing intermediate container 5ab38d216553
Step 7/10 : RUN rm -rf /tmp
 ---> Running in 4e05a4dae6be
 ---> 73d4e84bdd5a
Removing intermediate container 4e05a4dae6be
Step 8/10 : VOLUME /src
 ---> Running in c5ba256a1053
 ---> 8d0ce5efe841
Removing intermediate container c5ba256a1053
Step 9/10 : WORKDIR /src
 ---> 2de72674d222
Removing intermediate container 913079c8fe6d
Step 10/10 : ENTRYPOINT rumbda
 ---> Running in d063782ad686
 ---> 04281af5d77d
Removing intermediate container d063782ad686
Successfully built 04281af5d77d
Successfully tagged rumbda:latest
```

To run rumbda:
```bash
 % docker run --rm -it -v "$PWD":/src rumbda:latest init
Created: /src/source
Created: /src/source/main.rb
Created: /src/.ruby-version
Created: /src/.gitignore
```
