### PR TITLE
build with system calls instead of FileUtils

### DIFF
--- a/lib/rumbda/build.rb
+++ b/lib/rumbda/build.rb
@@ -83,7 +83,7 @@ module Rumbda
       Bundler.with_clean_env do
         success = system(
           "cd #{dir_with_gemfile} && " \
-          'env BUNDLE_IGNORE_CONFIG=1 bundle install --path . --without development'
+          'env BUNDLE_IGNORE_CONFIG=1 bundle install --path . --without development --deployment --clean'
         )
 
         abort('Bundle install failed, exiting.') unless success


### PR DESCRIPTION
Thanks for your really great work on this gem! Helped me to get ruby running on lambda in no time. At Vydia we will be productionalizing ruby code on lambda in no time, and I'd love to be able to use this gem and contribute back to it as we learn more moving forward.

However, I ran into some interesting anomalous behavior during `rumbda build`, which this PR should alleviate. I also added [`--clean`](http://bundler.io/man/bundle-install.1.html#OPTIONS) and [`--deployment`](http://bundler.io/man/bundle-install.1.html#DEPLOYMENT-MODE) flags to the `bundle install` command during build.

## Anomalous FileUtils behavior

### FileUtils truncating dest rb files

I have no explanation for why this was happening, but it was consistent and very frustrating. I tried using `:verbose => true` option, nothing. Tried rewriting using FIleUtils in many different ways, 
nothing. After spending hours with no results I gave up on FileUtils and rewrote using system calls.

Whole source file:
![screen shot 2018-04-01 at 10 57 48 am](https://user-images.githubusercontent.com/4197823/38175564-79ce4bfa-35ac-11e8-9f32-69e2141a86b3.png)

Truncated dest file:
![screen shot 2018-04-01 at 10 58 03 am](https://user-images.githubusercontent.com/4197823/38175566-817e8338-35ac-11e8-8b5f-f210899bfdfc.png)

### FileUtils using stale versions of source files 

No matter what cache I clear, how many times restarting the machine, this line
https://github.com/kleaver/rumbda/blob/cda8f9d3cf296c38fa389ac0c906ca166750e999/lib/rumbda/build.rb#L18
consistently only results in stale versions of the file being copied to dest. The only workaround was to rename the file, which would work one time, but then making changes to that file have the same results after any updates are made. :goberserk: 

Modified source file:
![screen shot 2018-04-01 at 11 16 15 am](https://user-images.githubusercontent.com/4197823/38175571-96100b28-35ac-11e8-9193-44b963f372a5.png)

Unmodified dest file:
![screen shot 2018-04-01 at 11 16 25 am](https://user-images.githubusercontent.com/4197823/38175582-a6bb02c0-35ac-11e8-95d0-40590ace854a.png)

## Success!

Using this commit's patch version in my Gemfile,

```ruby
group :development do
  gem "rumbda", :github => "Vydia/rumbda", :ref => "19e3016e2d3659a771c0a6933e4e4b3a51561eef"
end
```

here we are, running on lambda finally. Changes respected, truncation ceased, and gems cleaned.

![screen shot 2018-04-01 at 1 09 24 pm](https://user-images.githubusercontent.com/4197823/38175653-f94c461a-35ad-11e8-8893-04825342c648.png)
